### PR TITLE
Fix sensor collection in case of lack of permission

### DIFF
--- a/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/AudioCollector.java
+++ b/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/AudioCollector.java
@@ -160,6 +160,7 @@ public class AudioCollector extends AsynchronousCollector {
     @RequiresApi(api = Build.VERSION_CODES.O)
     private void startRecording(File file) throws IOException {
         mMediaRecorder = new MediaRecorder();
+        // may throw IllegalStateException due to lack of permission
         mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
         mMediaRecorder.setAudioChannels(2);
         mMediaRecorder.setAudioSamplingRate(44100);
@@ -173,8 +174,17 @@ public class AudioCollector extends AsynchronousCollector {
 
     private void stopRecording() {
         if (mMediaRecorder != null) {
-            mMediaRecorder.stop();
-            mMediaRecorder.release();
+            try {
+                // may throw IllegalStateException because no valid audio data has been received
+                mMediaRecorder.stop();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            try {
+                mMediaRecorder.release();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             mMediaRecorder = null;
         }
     }

--- a/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/BluetoothCollector.java
+++ b/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/BluetoothCollector.java
@@ -154,7 +154,8 @@ public class BluetoothCollector extends AsynchronousCollector {
                 stopScan();
                 result.setErrorCode(7);
                 result.setErrorReason(e.toString());
-                ft.complete(result);
+//                ft.complete(result);
+                ft.completeExceptionally(e);
                 isCollecting.set(false);
             }
         } else {

--- a/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/GPSCollector.java
+++ b/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/GPSCollector.java
@@ -40,7 +40,7 @@ public class GPSCollector extends AsynchronousCollector implements LocationListe
         2: Concurrent task of GPS collecting
         3: Unknown exception when stopping collecting
         4: Invalid GPS request time
-        5: Unknown collecting exception
+        5: Unknown collecting exception (may be binding listener error due to lack of permission)
      */
 
     public GPSCollector(Context context, CollectorManager.CollectorType type, ScheduledExecutorService scheduledExecutorService, List<ScheduledFuture<?>> futureList) {
@@ -141,7 +141,8 @@ public class GPSCollector extends AsynchronousCollector implements LocationListe
                 unbindListener();
                 result.setErrorCode(5);
                 result.setErrorReason(e.toString());
-                ft.complete(result);
+//                ft.complete(result);
+                ft.completeExceptionally(e);
                 isCollecting.set(false);
             }
         } else {

--- a/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/WifiCollector.java
+++ b/android/DataCollection/ContextActionLibrary/src/main/java/com/hcifuture/contextactionlibrary/sensor/collector/async/WifiCollector.java
@@ -186,8 +186,10 @@ public class WifiCollector extends AsynchronousCollector {
                 e.printStackTrace();
                 result.setErrorCode(4);
                 result.setErrorReason(e.toString());
-                ft.complete(result);
+//                ft.complete(result);
+                ft.completeExceptionally(e);
                 isCollecting.set(false);
+                isScanning.set(false);
             }
         } else {
             result.setErrorCode(3);


### PR DESCRIPTION
- Fix missing catch of exception during audio recording stop(), which can happen in case of lack of permission
- Bluetooth, Wifi & GPS: complete future exceptionally when encountering unknown collecting error (like lack of permission) instead of providing blank result